### PR TITLE
Remove unnecessary print statement

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -367,7 +367,6 @@ class StripedHyena(nn.Module):
         return x, None
 
     def initialize_inference_params(self):
-        print_rank_0("Initializing inference params...")
         inference_params_dict = {
             "mha": InferenceParams(
                 max_seqlen=self.config.get("max_seqlen", 8192),


### PR DESCRIPTION
Open to keeping this, but it introduces one line of unnecessary printing every time we sample a set of sequences.